### PR TITLE
Update gem email and homepage for move to SIMP org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in scelint.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.11'

--- a/lib/scelint/version.rb
+++ b/lib/scelint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scelint
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/scelint.gemspec
+++ b/scelint.gemspec
@@ -1,28 +1,28 @@
 require_relative 'lib/scelint/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "scelint"
+  spec.name          = 'scelint'
   spec.version       = Scelint::VERSION
-  spec.authors       = ["Steven Pritchard"]
-  spec.email         = ["steven.pritchard@onyxpoint.com"]
+  spec.authors       = ['Steven Pritchard']
+  spec.email         = ['simp@simp-project.org']
   spec.license       = 'Apache-2.0'
 
   spec.summary       = %q{Linter SIMP Compliance Engine data}
-  spec.homepage      = "https://github.com/silug/rubygem-simp-scelint"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.homepage      = 'https://github.com/simp/rubygem-simp-scelint'
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  # spec.metadata['changelog_uri'] = 'TODO: Put your gem's CHANGELOG.md URL here.'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'deep_merge'
 end


### PR DESCRIPTION
* Update `spec.email` and `spec.homepage`
* Require ruby >= 2.6.0 in `spec.required_ruby_version`
* Use single quotes consistently in Gemfile and gemspec
* Bump version to 0.2.0

Fixes #15