### PR TITLE
Drop minimum ruby version to work with Puppet 6

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'
@@ -29,6 +30,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '2.5'
           - '2.6'
           - '2.7'
           - '3.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -520,13 +520,7 @@ Style/RedundantArgument:
   Enabled: false
 Style/SwapValues:
   Enabled: false
-Gemspec/DeprecatedAttributeAssignment:
-  Enabled: false
 Gemspec/RequireMFA:
-  Enabled: false
-Layout/LineContinuationLeadingSpace:
-  Enabled: false
-Layout/LineContinuationSpacing:
   Enabled: false
 Layout/LineEndStringConcatenationIndentation:
   Enabled: false
@@ -538,8 +532,6 @@ Lint/AmbiguousOperatorPrecedence:
   Enabled: true
 Lint/AmbiguousRange:
   Enabled: true
-Lint/ConstantOverwrittenInRescue:
-  Enabled: true
 Lint/DeprecatedConstants:
   Enabled: true
 Lint/EmptyInPattern:
@@ -548,8 +540,6 @@ Lint/IncompatibleIoSelectWithFiberScheduler:
   Enabled: true
 Lint/LambdaWithoutLiteralBlock:
   Enabled: true
-Lint/NonAtomicFileOperation:
-  Enabled: true
 Lint/NumberedParameterAssignment:
   Enabled: true
 Lint/OrAssignmentToConstant:
@@ -557,8 +547,6 @@ Lint/OrAssignmentToConstant:
 Lint/RedundantDirGlobSort:
   Enabled: true
 Lint/RefinementImportMethods:
-  Enabled: true
-Lint/RequireRangeParentheses:
   Enabled: true
 Lint/RequireRelativeSelfPath:
   Enabled: true
@@ -574,11 +562,7 @@ Security/CompoundHash:
   Enabled: true
 Security/IoMethods:
   Enabled: true
-Style/EmptyHeredoc:
-  Enabled: true
 Style/EndlessMethod:
-  Enabled: true
-Style/EnvHome:
   Enabled: true
 Style/FetchEnvVar:
   Enabled: true
@@ -593,10 +577,6 @@ Style/HashExcept:
 Style/IfWithBooleanLiteralBranches:
   Enabled: true
 Style/InPatternThen:
-  Enabled: true
-Style/MagicCommentFormat:
-  Enabled: true
-Style/MapCompactWithConditionalBlock:
   Enabled: true
 Style/MapToHash:
   Enabled: true
@@ -636,27 +616,15 @@ RSpec/BeEq:
   Enabled: true
 RSpec/BeNil:
   Enabled: true
-RSpec/ChangeByZero:
-  Enabled: true
-RSpec/ClassCheck:
-  Enabled: true
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
 RSpec/IdenticalEqualityAssertion:
-  Enabled: true
-RSpec/NoExpectationExample:
   Enabled: true
 RSpec/SubjectDeclaration:
   Enabled: true
 RSpec/VerifiedDoubleReference:
   Enabled: true
-RSpec/Capybara/SpecificFinders:
-  Enabled: false
-RSpec/Capybara/SpecificMatcher:
-  Enabled: false
 RSpec/FactoryBot/SyntaxMethods:
   Enabled: false
 RSpec/Rails/AvoidSetupHook:
-  Enabled: false
-RSpec/Rails/HaveHttpStatus:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem 'rake', '~> 13.0'
 
 group :tests do
   gem 'rspec', '~> 3.11'
-  gem 'rubocop', '~> 1.36'
-  gem 'rubocop-performance', '~> 1.15'
-  gem 'rubocop-rspec', '~> 2.13'
+  gem 'rubocop', '~> 1.28'
+  gem 'rubocop-performance', '~> 1.13'
+  gem 'rubocop-rspec', '~> 2.10'
   gem 'rubocop-rake', '~> 0.6.0'
 end

--- a/scelint.gemspec
+++ b/scelint.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Linter SIMP Compliance Engine data}
   spec.homepage      = 'https://github.com/simp/rubygem-simp-scelint'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
* Roll back various gems to ruby 2.5-compatible versions
* Fix up cops to match older rubocop
* Add ruby 2.5 to test matrix

Fixes #21