### PR TITLE
Updates for recent rubocop and plugins

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7'  # Puppet 7
           - '3.2'  # Puppet 8
-          - '3.3'  # Latest
+          - '3.3'
+          - '3.4'  # Latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tag_deploy_rubygem.yml
+++ b/.github/workflows/tag_deploy_rubygem.yml
@@ -92,7 +92,7 @@ jobs:
           echo "release_command=$GEM_RELEASE_COMMAND" | tee -a "$GITHUB_OUTPUT"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
           bundler-cache: true
       - name: Test build the package
         run: "${{ steps.commands.outputs.build_command }}"
@@ -187,7 +187,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
           bundler-cache: true
       - name: Build RubyGem
         run: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,11 @@
 ---
-require:
+plugins:
   - rubocop-performance
   - rubocop-rspec
   - rubocop-rake
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: "2.7"
+  TargetRubyVersion: 2.7
   Include:
     - "**/*.rb"
     - Gemfile
@@ -744,5 +744,49 @@ Performance/MapMethodChain:
   Enabled: true
 Performance/StringBytesize:
   Enabled: true
-RSpec/StringAsInstanceDoubleConstant:
+Gemspec/AttributeAssignment:
+  Enabled: true
+Layout/EmptyLinesAfterModuleInclusion:
+  Enabled: true
+Lint/ArrayLiteralInRegexp:
+  Enabled: true
+Lint/ConstantReassignment:
+  Enabled: true
+Lint/CopDirectiveSyntax:
+  Enabled: true
+Lint/RedundantTypeConversion:
+  Enabled: true
+Lint/SharedMutableDefault:
+  Enabled: true
+Lint/SuppressedExceptionInNumberConversion:
+  Enabled: true
+Lint/UselessConstantScoping:
+  Enabled: true
+Lint/UselessDefaultValueArgument:
+  Enabled: true
+Lint/UselessOr:
+  Enabled: true
+Naming/PredicateMethod:
+  Enabled: true
+Style/CollectionQuerying:
+  Enabled: true
+Style/ComparableBetween:
+  Enabled: true
+Style/EmptyStringInsideInterpolation:
+  Enabled: true
+Style/HashFetchChain:
+  Enabled: true
+Style/HashSlice:
+  Enabled: true
+Style/ItAssignment:
+  Enabled: true
+Style/ItBlockParameter:
+  Enabled: true
+Style/RedundantArrayFlatten:
+  Enabled: true
+Style/RedundantFormat:
+  Enabled: true
+Performance/ZipWithoutBlock:
+  Enabled: true
+RSpec/IncludeExamples:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ plugins:
   - rubocop-rake
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   Include:
     - "**/*.rb"
     - Gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 0.3.1 / 2025-08-26
-* Updates for rubocop 1.80.0
+### 0.4.0 / 2025-08-26
+* Updates for recent rubocop and plugins
+* Bump minimum required Ruby version to 3.2.0 (oldest version we're testing with)
 
 ### 0.3.0 / 2025-01-16
 * Use compliance_engine gem for data ingest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.3.1 / 2025-08-26
+* Updates for rubocop 1.80.0
+
 ### 0.3.0 / 2025-01-16
 * Use compliance_engine gem for data ingest
 * Check that all fact combinations return hiera data

--- a/Gemfile
+++ b/Gemfile
@@ -3,18 +3,18 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in scelint.gemspec
 gemspec
 
-gem 'rake', '~> 13.2'
+gem 'rake', '~> 13.3.0'
 
 group :tests do
-  gem 'rspec', '~> 3.13'
-  gem 'rubocop', '~> 1.65'
-  gem 'rubocop-performance', '~> 1.21'
-  gem 'rubocop-rake', '~> 0.6.0'
-  gem 'rubocop-rspec', '~> 3.0'
+  gem 'rspec', '~> 3.13.1'
+  gem 'rubocop', '~> 1.80.0'
+  gem 'rubocop-performance', '~> 1.25.0'
+  gem 'rubocop-rake', '~> 0.7.1'
+  gem 'rubocop-rspec', '~> 3.6.0'
 end
 
 group :development do
-  gem 'pry', '~> 0.14.1'
-  gem 'pry-byebug', '~> 3.10'
-  gem 'rdoc', '~> 6.4'
+  gem 'pry', '~> 0.15.2'
+  gem 'pry-byebug', '~> 3.11.0'
+  gem 'rdoc', '~> 6.14.2'
 end

--- a/lib/scelint.rb
+++ b/lib/scelint.rb
@@ -460,7 +460,7 @@ module Scelint
     # @param _check [String] The name of the check (currently unused)
     # @param _value [Object] The value to be validated (currently unused)
     # @return [Boolean] Always returns true (currently)
-    def check_value(_file, _check, _value)
+    def check_value(_file, _check, _value) # rubocop:disable Naming/PredicateMethod
       # value could be anything
       true
     end

--- a/lib/scelint/cli.rb
+++ b/lib/scelint/cli.rb
@@ -36,7 +36,7 @@ class Scelint::CLI < Thor
     end
 
     message = "Checked #{count} files."
-    if lint.errors.count == 0
+    if lint.errors.empty?
       message += '  No errors.'
       exit_code = 0
     else
@@ -44,12 +44,12 @@ class Scelint::CLI < Thor
       exit_code = 1
     end
 
-    if lint.warnings.count > 0
+    unless lint.warnings.empty?
       message += "  #{lint.warnings.count} warnings."
       exit_code = 1 if options[:strict]
     end
 
-    message += " #{lint.notes.count} notes." if lint.notes.count > 0
+    message += " #{lint.notes.count} notes." unless lint.notes.empty?
 
     logger.info message
     exit exit_code

--- a/lib/scelint/version.rb
+++ b/lib/scelint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scelint
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/lib/scelint/version.rb
+++ b/lib/scelint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scelint
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 end

--- a/scelint.gemspec
+++ b/scelint.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Linter SIMP Compliance Engine data'
   spec.homepage      = 'https://github.com/simp/rubygem-simp-scelint'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.2.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
* Bump minimum required Ruby version to 3.2.0 (oldest version we're testing with)

Fixes #42